### PR TITLE
Refactor CI/CD pipeline to separate build and merge stages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,32 +11,22 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_REPOS: |
-    ghcr.io/dictcp/utils
+  IMAGE_NAME: ghcr.io/dictcp/utils
 
 jobs:
-  buildx:
-    # matrix magic
+  build-amd64:
     strategy:
       matrix:
         target: [full, ubuntu2604, ubuntu2404, ubuntu2204, alpine]
       fail-fast: false
-    # end matrix magic
     runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
         uses: actions/checkout@v6
       -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
         name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -49,19 +39,132 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_REPOS }}
+          images: ${{ env.IMAGE_NAME }}
+      -
+        name: Build and push by digest (linux/amd64)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.${{ matrix.target }}
+          platforms: linux/amd64
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-amd64-${{ matrix.target }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-arm:
+    strategy:
+      matrix:
+        target: [full, ubuntu2604, ubuntu2404, ubuntu2204, alpine]
+      fail-fast: false
+    runs-on: ubuntu-24.04-arm
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v6
+      -
+        name: Set up QEMU (riscv64 only, for ubuntu2604)
+        if: matrix.target == 'ubuntu2604'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      -
+        name: Build and push by digest (arm)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.${{ matrix.target }}
+          platforms: ${{ matrix.target == 'ubuntu2604' && 'linux/arm64,linux/arm/v7,linux/riscv64' || 'linux/arm64' }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-arm-${{ matrix.target }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build-amd64, build-arm]
+    strategy:
+      matrix:
+        target: [full, ubuntu2604, ubuntu2404, ubuntu2204, alpine]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*-${{ matrix.target }}
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ matrix.target }}
             type=raw,value=latest,enable=${{ matrix.target == 'ubuntu2604' }}
             type=raw,value=lite,enable=${{ matrix.target == 'ubuntu2604' }}
             type=raw,value=ubuntu,enable=${{ matrix.target == 'ubuntu2604' }}
       -
-        name: Build and push (${{ matrix.target }})
-        uses: docker/build-push-action@v6
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          context: .
-          file: Dockerfile.${{ matrix.target }}
-          platforms: ${{ matrix.target == 'ubuntu2604' && 'linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64' || 'linux/amd64,linux/arm64' }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary
Restructured the GitHub Actions workflow to implement a multi-stage build process that separates architecture-specific builds (amd64 and ARM) from the final manifest creation and push. This enables more efficient parallel builds and better handling of multi-architecture image creation.

## Key Changes
- **Split single job into three jobs:**
  - `build-amd64`: Builds images for linux/amd64 architecture on ubuntu-latest
  - `build-arm`: Builds images for ARM architectures (arm64, arm/v7, and riscv64 for ubuntu2604) on ubuntu-24.04-arm
  - `merge`: Downloads digests from both builds and creates final multi-architecture manifest lists

- **Simplified environment variables:**
  - Changed `IMAGE_REPOS` (multi-line) to `IMAGE_NAME` (single value) for cleaner configuration

- **Implemented digest-based workflow:**
  - Each build job exports image digests to artifacts instead of directly pushing tags
  - Merge job downloads all digests and uses `docker buildx imagetools create` to combine them into multi-architecture manifests
  - This approach allows independent architecture builds to complete before final manifest creation

- **Conditional QEMU setup:**
  - QEMU is now only set up for ubuntu2604 target on ARM runner (needed for riscv64 support)
  - Removed unnecessary QEMU setup from amd64 builds

- **Enhanced metadata handling:**
  - Tags are now applied during the merge stage rather than individual builds
  - Added image inspection step to verify final manifest creation

## Implementation Details
- Build jobs use `push-by-digest=true` to push images without tags, storing only the digest references
- Merge job depends on both build jobs completing successfully via `needs: [build-amd64, build-arm]`
- Artifacts are retained for only 1 day to minimize storage usage
- The workflow maintains support for all five target variants (full, ubuntu2604, ubuntu2404, ubuntu2204, alpine)

https://claude.ai/code/session_01Nr2cib6QkdXxvTFGWVHurp