### PR TITLE
ci: native multi-arch builds with no QEMU emulation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,12 +76,6 @@ jobs:
         name: Checkout
         uses: actions/checkout@v6
       -
-        name: Set up QEMU (riscv64 only, for ubuntu2604)
-        if: matrix.target == 'ubuntu2604'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: riscv64
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
@@ -98,13 +92,13 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
       -
-        name: Build and push by digest (arm)
+        name: Build and push by digest (linux/arm64 + linux/arm/v7)
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.${{ matrix.target }}
-          platforms: ${{ matrix.target == 'ubuntu2604' && 'linux/arm64,linux/arm/v7,linux/riscv64' || 'linux/arm64' }}
+          platforms: ${{ matrix.target == 'ubuntu2604' && 'linux/arm64,linux/arm/v7' || 'linux/arm64' }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
       -
@@ -122,8 +116,56 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-riscv:
+    # riscv64 is only needed for the ubuntu2604 target
+    runs-on: ubuntu-24.04-riscv
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v6
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      -
+        name: Build and push by digest (linux/riscv64)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ubuntu2604
+          platforms: linux/riscv64
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-riscv-ubuntu2604
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   merge:
-    needs: [build-amd64, build-arm]
+    needs: [build-amd64, build-arm, build-riscv]
     strategy:
       matrix:
         target: [full, ubuntu2604, ubuntu2404, ubuntu2204, alpine]


### PR DESCRIPTION
## Summary

- Replace the single QEMU-emulated `buildx` job with three parallel native build jobs (`build-amd64`, `build-arm`, `build-riscv`) plus a `merge` job that assembles the final multi-arch manifest
- `build-arm` runs on `ubuntu-24.04-arm` (Cobalt 100) — builds `linux/arm64` and `linux/arm/v7` natively for `ubuntu2604`, `linux/arm64` for all other targets
- `build-riscv` runs on `ubuntu-24.04-riscv` (RISE project, Scaleway EM-RV1) — builds `linux/riscv64` natively for the `ubuntu2604` target only; no matrix needed
- Zero QEMU across all jobs; each platform is built on its own native runner
- Each build job pushes by digest (no tags); the `merge` job downloads all digests and creates the final tagged manifest list via `docker buildx imagetools create`

## Platform mapping

| Job | Runner | Platforms |
|-----|--------|-----------|
| `build-amd64` | `ubuntu-latest` | `linux/amd64` |
| `build-arm` | `ubuntu-24.04-arm` | `linux/arm64`, `linux/arm/v7` (ubuntu2604 only) |
| `build-riscv` | `ubuntu-24.04-riscv` | `linux/riscv64` (ubuntu2604 only) |
| `merge` | `ubuntu-latest` | combines all digests |

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` and confirm all three build jobs complete on their respective runners
- [ ] Confirm `merge` job produces correct multi-arch manifest for `ubuntu2604` (should list amd64, arm64, arm/v7, riscv64)
- [ ] Confirm other targets (full, ubuntu2404, ubuntu2204, alpine) produce amd64 + arm64 manifests
- [ ] Verify pushed image tags (`latest`, `ubuntu`, `lite`, `ubuntu2604`) resolve correctly on ghcr.io

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr2cib6QkdXxvTFGWVHurp)_