### PR TITLE
ci: isolate riscv build failure from non-riscv merge jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,6 +166,11 @@ jobs:
 
   merge:
     needs: [build-amd64, build-arm, build-riscv]
+    if: |
+      always() &&
+      needs.build-amd64.result == 'success' &&
+      needs.build-arm.result == 'success' &&
+      (matrix.target != 'ubuntu2604' || needs.build-riscv.result == 'success')
     strategy:
       matrix:
         target: [full, ubuntu2604, ubuntu2404, ubuntu2204, alpine]


### PR DESCRIPTION
## Summary

- Add a job-level `if` condition to the `merge` job so a `build-riscv` failure (e.g. RISE runner outage) only blocks the `ubuntu2604` merge — all other targets (`full`, `ubuntu2404`, `ubuntu2204`, `alpine`) continue as long as `build-amd64` and `build-arm` pass.

## Before / after

**Before:** `build-riscv` failure → all 5 `merge` matrix jobs skipped  
**After:** `build-riscv` failure → only `ubuntu2604` merge skipped; other 4 targets unaffected

## Condition logic

```yaml
if: |
  always() &&
  needs.build-amd64.result == 'success' &&
  needs.build-arm.result == 'success' &&
  (matrix.target != 'ubuntu2604' || needs.build-riscv.result == 'success')
```

## Test plan

- [ ] Simulate `build-riscv` failure and confirm `full`, `ubuntu2404`, `ubuntu2204`, `alpine` merge jobs still complete
- [ ] Confirm `ubuntu2604` merge is correctly skipped when `build-riscv` fails

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr2cib6QkdXxvTFGWVHurp)_