### PR TITLE
docker: multi-stage build for Dockerfile.full

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -14,6 +14,6 @@ RUN apt-get update && \
     python3-minimal ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /root/go/bin/wireproxy /usr/local/bin/
-COPY --from=builder /root/go/bin/derper /usr/local/bin/
-COPY --from=builder /root/go/bin/sniproxy /usr/local/bin/
+COPY --from=builder /go/bin/wireproxy /usr/local/bin/
+COPY --from=builder /go/bin/derper /usr/local/bin/
+COPY --from=builder /go/bin/sniproxy /usr/local/bin/

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,4 +1,10 @@
-FROM golang:1.26.3-trixie
+FROM golang:1.26.3-trixie AS builder
+
+RUN go install github.com/windtf/wireproxy/cmd/wireproxy@v1.1.2
+RUN go install tailscale.com/cmd/derper@latest
+RUN go install github.com/ameshkov/sniproxy@v1.6.1
+
+FROM ubuntu:26.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
@@ -8,8 +14,6 @@ RUN apt-get update && \
     python3-minimal ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN go install github.com/windtf/wireproxy/cmd/wireproxy@v1.1.2
-
-RUN go install tailscale.com/cmd/derper@latest
-
-RUN go install github.com/ameshkov/sniproxy@v1.6.1
+COPY --from=builder /root/go/bin/wireproxy /usr/local/bin/
+COPY --from=builder /root/go/bin/derper /usr/local/bin/
+COPY --from=builder /root/go/bin/sniproxy /usr/local/bin/

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -4,7 +4,7 @@ RUN go install github.com/windtf/wireproxy/cmd/wireproxy@v1.1.2
 RUN go install tailscale.com/cmd/derper@latest
 RUN go install github.com/ameshkov/sniproxy@v1.6.1
 
-FROM ubuntu:26.04
+FROM debian:trixie-slim
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \


### PR DESCRIPTION
## Summary

- Convert `Dockerfile.full` to a multi-stage build to drop the Go SDK from the final image (~1 GB savings)
- Builder stage: `golang:1.26.3-trixie` compiles `wireproxy`, `derper`, and `sniproxy`
- Final stage: `debian:trixie-slim` — matches the builder's Debian release for identical glibc version and guaranteed CGo compatibility; all required packages confirmed available in Trixie

## Before / after

| | Before | After |
|---|---|---|
| Base | `golang:1.26.3-trixie` (~900 MB) | `debian:trixie-slim` (~80 MB) |
| Go SDK in final image | Yes | No |
| Binaries | Built in place | Copied from builder stage |

## Test plan

- [ ] Confirm `wireproxy`, `derper`, `sniproxy` binaries are present and executable in the final image
- [ ] Confirm all runtime packages install cleanly on `debian:trixie-slim`
- [ ] Verify multi-arch build succeeds for `linux/amd64` and `linux/arm64`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr2cib6QkdXxvTFGWVHurp)_