### PR TITLE
ci/docs: move riscv64 + arm/v7 to ubuntu2404; promote ubuntu2404 as default tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,13 +92,13 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
       -
-        name: Build and push by digest (linux/arm64 + linux/arm/v7)
+        name: Build and push by digest (arm)
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.${{ matrix.target }}
-          platforms: ${{ matrix.target == 'ubuntu2604' && 'linux/arm64,linux/arm/v7' || 'linux/arm64' }}
+          platforms: ${{ matrix.target == 'ubuntu2404' && 'linux/arm64,linux/arm/v7' || 'linux/arm64' }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
       -
@@ -117,7 +117,8 @@ jobs:
           retention-days: 1
 
   build-riscv:
-    # riscv64 is only needed for the ubuntu2604 target
+    # riscv64 is only for the ubuntu2404 target — ubuntu2604 binaries use Zba/Zbb
+    # extensions not supported on older RISC-V cores (e.g. T-Head C910)
     runs-on: ubuntu-24.04-riscv
     steps:
       -
@@ -145,7 +146,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.ubuntu2604
+          file: Dockerfile.ubuntu2404
           platforms: linux/riscv64
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
@@ -159,7 +160,7 @@ jobs:
         name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-riscv-ubuntu2604
+          name: digests-riscv-ubuntu2404
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -168,7 +169,7 @@ jobs:
     needs: [build-amd64, build-arm]
     strategy:
       matrix:
-        target: [full, ubuntu2404, ubuntu2204, alpine]
+        target: [full, ubuntu2604, ubuntu2204, alpine]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -190,6 +191,7 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ matrix.target }}
+            type=raw,value=ubuntu,enable=${{ matrix.target == 'ubuntu2604' }}
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -208,7 +210,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  merge-ubuntu2604:
+  merge-ubuntu2404:
     needs: [build-amd64, build-arm, build-riscv]
     runs-on: ubuntu-latest
     steps:
@@ -217,7 +219,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*-ubuntu2604
+          pattern: digests-*-ubuntu2404
           merge-multiple: true
       -
         name: Set up Docker Buildx
@@ -229,10 +231,9 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=ubuntu2604
+            type=raw,value=ubuntu2404
             type=raw,value=latest
             type=raw,value=lite
-            type=raw,value=ubuntu
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -249,4 +250,4 @@ jobs:
       -
         name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:ubuntu2604
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:ubuntu2404

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ docker run --rm -it ghcr.io/dictcp/utils /bin/bash
 
 Supported tags and respective Dockerfile links
 ----
-- [`ubuntu2604`, `ubuntu`, `latest`](https://github.com/dictcp/docker-utils/blob/master/Dockerfile.ubuntu2604)
-- [`ubuntu2404`](https://github.com/dictcp/docker-utils/blob/master/Dockerfile.ubuntu2404)
+- [`ubuntu2404`, `latest`, `lite`](https://github.com/dictcp/docker-utils/blob/master/Dockerfile.ubuntu2404)
+- [`ubuntu2604`, `ubuntu`](https://github.com/dictcp/docker-utils/blob/master/Dockerfile.ubuntu2604)
 - [`ubuntu2204`](https://github.com/dictcp/docker-utils/blob/master/Dockerfile.ubuntu2204)
 - ~~`ubuntu2004`~~ EOLed
 - ~~`ubuntu1804`~~ EOLed
@@ -24,5 +24,7 @@ Supported arch
 ----
 - x86-64 (aka. `linux/amd64` platform in Docker)
 - armv8 (aka. `linux/arm64` platform in Docker)
-- armv7 (aka. `linux/amd/v7` platform in Docker) **ONLY for ubuntu 26.04**
-- riscv64 (aka `linux/riscv64` platform in Docker) **ONLY for ubuntu 26.04**
+- armv7 (aka. `linux/arm/v7` platform in Docker) **ONLY for ubuntu 24.04**
+- riscv64 (aka. `linux/riscv64` platform in Docker) **ONLY for ubuntu 24.04**
+  - Targets **RV64GC + lp64d ABI**, which covers the vast majority of RISC-V boards in the wild.
+  - Ubuntu 26.04's riscv64 port raises the minimum ISA profile to include Zba/Zbb (bit manipulation) extensions. Many current cores — such as the T-Head C910 found in boards like the Sipeed LM3A / Scaleway EM-RV1 — do not implement these standard encodings, causing an immediate `SIGILL` at runtime. Ubuntu 24.04 stays on the conservative RV64GC baseline and runs correctly on those cores.


### PR DESCRIPTION
## Summary

Moves `linux/riscv64` and `linux/arm/v7` from `ubuntu2604` to `ubuntu2404`, and promotes `ubuntu2404` as the default (`latest`/`lite`) tag.

### Platform changes

| Target | Before | After |
|--------|--------|-------|
| `ubuntu2604` | amd64, arm64, arm/v7, riscv64 | amd64, arm64 |
| `ubuntu2404` | amd64, arm64 | amd64, arm64, **arm/v7**, **riscv64** |

### Tag changes

| Tag | Before | After |
|-----|--------|-------|
| `latest`, `lite` | → ubuntu2604 | → ubuntu2404 |
| `ubuntu` | → ubuntu2604 | → ubuntu2604 (unchanged) |

### Why ubuntu2604 can't carry riscv64

Ubuntu 26.04's riscv64 port raises the minimum ISA profile to include Zba/Zbb (bit manipulation) extensions. Older cores such as the T-Head C910 (Sipeed LM3A, Scaleway EM-RV1) don't implement these standard encodings and immediately SIGILL. Ubuntu 24.04 stays on the conservative RV64GC + lp64d ABI baseline and runs correctly on those cores.

### Workflow changes

- `build-arm`: arm/v7 condition flipped to `ubuntu2404`
- `build-riscv`: now targets `Dockerfile.ubuntu2404`, artifact renamed to `digests-riscv-ubuntu2404`
- `merge` matrix: `[full, ubuntu2604, ubuntu2204, alpine]` — ubuntu2604 gets `ubuntu` alias tag
- `merge-ubuntu2604` → replaced by `merge-ubuntu2404` (carries `latest`, `lite`, `ubuntu2404` tags, depends on `build-riscv`)

## Test plan

- [ ] Confirm `ubuntu2404` manifest includes amd64, arm64, arm/v7, riscv64
- [ ] Confirm `ubuntu2604` manifest includes amd64, arm64 only
- [ ] Confirm `latest` and `lite` resolve to the `ubuntu2404` image
- [ ] Confirm `ubuntu` resolves to the `ubuntu2604` image

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr2cib6QkdXxvTFGWVHurp)_